### PR TITLE
Add PyOpenGL to requirements.txt for RLlib video rendering since not …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ gym==0.21
 pyglet
 tabulate
 opencv-python-headless
+PyOpenGL
 lz4
 tensorboardX
 tensorflow_probability


### PR DESCRIPTION
…automatically imported on Linux