### PR TITLE
Update RLlib Serve usage to Serve 2.0

### DIFF
--- a/ray-rllib/ex_05_rllib_and_ray_serve.ipynb
+++ b/ray-rllib/ex_05_rllib_and_ray_serve.ipynb
@@ -77,10 +77,6 @@
     }
    ],
    "source": [
-    "# Call `serve.start()` to get \n",
-    "serve.start()\n",
-    "\n",
-    "\n",
     "@serve.deployment(route_prefix=\"/serve-deployment\")\n",
     "class ServeModel:\n",
     "    def __init__(self, config, checkpoint) -> None:\n",
@@ -145,8 +141,8 @@
     }
    ],
    "source": [
-    "# In order to create a deployment from the tagge class above, simply call its `deploy()`\n",
-    "# method and pass this method the `ServeModel` constructor arguments:\n",
+    "# In order to create a deployment from the tagged class above, simply `.bind()`\n",
+    "# the deployments with its constructor arguments:\n",
     "\n",
     "# Create config to use. Same as before, but lighter:\n",
     "# 1) No evaluation necessary (model only used for inference).\n",
@@ -158,7 +154,8 @@
     "# Pick a solid checkpoint from the previous notebook's CRR experiment:\n",
     "checkpoint = \"results/CRR/CRR_Pendulum-v1_93a30_00000_0_2022-07-26_23-26-14/checkpoint_000028/checkpoint-28\"\n",
     "\n",
-    "ServeModel.deploy(config, checkpoint)\n",
+    "serve_model = ServeModel.bind(config, checkpoint)\n",
+    "serve.run(serve_model)\n",
     "    \n",
     "# That's it: Deployment created!"
    ]
@@ -339,7 +336,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.11",
    "language": "python",
    "name": "python3"
   },
@@ -353,7 +350,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.8.11"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "250a0c8ad49f9e0ab80d6ffa587b8bd67c2b62f7c5238d34c3fd259cc7d4f5bf"
+   }
   }
  },
  "nbformat": 4,

--- a/ray-rllib/ex_06_rllib_end_to_end_demo.ipynb
+++ b/ray-rllib/ex_06_rllib_end_to_end_demo.ipynb
@@ -626,10 +626,6 @@
     }
    ],
    "source": [
-    "# Call `serve.start()` to get \n",
-    "serve.start()\n",
-    "\n",
-    "\n",
     "@serve.deployment(route_prefix=\"/in-game-recommendations\")\n",
     "class ServeModel:\n",
     "    def __init__(self, config, checkpoint) -> None:\n",
@@ -647,8 +643,8 @@
     "        action = self.algo.compute_single_action(np_obs, explore=False)\n",
     "        return {\"action\": action}\n",
     "\n",
-    "\n",
-    "ServeModel.deploy(crr_config, last_checkpoint)\n",
+    "serve_model = ServeModel.bind(crr_config, last_checkpoint)\n",
+    "serve.run(serve_model)\n",
     "    \n",
     "# That's it: Deployment created!"
    ]
@@ -875,7 +871,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.11",
    "language": "python",
    "name": "python3"
   },
@@ -889,7 +885,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.8.11"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "250a0c8ad49f9e0ab80d6ffa587b8bd67c2b62f7c5238d34c3fd259cc7d4f5bf"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR replaces deprecated Serve APIs from the RLlib tutorials. 

I was unable to test these notebooks locally on master (the deployment failed to start), I think I'm supposed to run some prior notebooks first, or run it on Anyscale.  @christy or @sven1977 can you suggest the best way for me to test this before we merge this PR?