### PR TITLE
Add accelerate>=0.8.0 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ PyOpenGL
 lz4
 tensorboardX
 tensorflow_probability
+accelerate>=0.8.0


### PR DESCRIPTION
To fix `ImportError: cannot import name 'dispatch_model' from 'accelerate' (/home/ray/anaconda3/lib/python3.7/site-packages/accelerate/__init__.py)` when running Serve notebook 02 (XGboost + FastAPI + Serve)